### PR TITLE
Data in all methods

### DIFF
--- a/lib/prayermate_api.rb
+++ b/lib/prayermate_api.rb
@@ -102,7 +102,7 @@ module PrayerMateApi
       begin
         body = JSON.parse(response.body)
       rescue => error
-        body = { "errors": error.to_s }
+        body = { "errors" => error.to_s }
       end
       return body if response.code == 200
 

--- a/lib/prayermate_api.rb
+++ b/lib/prayermate_api.rb
@@ -22,6 +22,11 @@ module PrayerMateApi
     attr_accessor :url_prefix, :api_key, :session_token, :email
 
     def initialize(protocol, host, api_key, session = nil)
+
+      if protocol.nil? || host.nil? || api_key.nil?
+        raise PrayerMateApiException.new "Missing parameters: protocol: #{protocol}, host: #{host}, api_key: #{api_key}"
+      end
+
       self.url_prefix = "#{protocol}://#{host}/api"
       self.api_key = api_key
 

--- a/lib/prayermate_api.rb
+++ b/lib/prayermate_api.rb
@@ -77,13 +77,13 @@ module PrayerMateApi
       process_response response
     end
 
-    def put_with_auth(endpoint)
-      response = HTTParty.put(api_path(endpoint), headers: http_headers, basic_auth: auth_hash)
+    def put_with_auth(endpoint, data = nil)
+      response = HTTParty.put(api_path(endpoint), body: data, headers: http_headers, basic_auth: auth_hash)
       process_response response
     end
 
-    def get_with_auth(endpoint)
-      response = HTTParty.get(api_path(endpoint), headers: http_headers, basic_auth: auth_hash)
+    def get_with_auth(endpoint, data = nil)
+      response = HTTParty.get(api_path(endpoint), body: data, headers: http_headers, basic_auth: auth_hash)
       process_response response
     end
 
@@ -97,11 +97,11 @@ module PrayerMateApi
       begin
         body = JSON.parse(response.body)
       rescue => error
-        body = { errors: error.to_s }
+        body = { "errors": error.to_s }
       end
       return body if response.code == 200
 
-      raise PrayerMateApiException, "Status code #{response.code}: #{body[:errors]}"
+      raise PrayerMateApiException, "Status code #{response.code}: #{body["errors"]}"
     end
 
     def auth_hash

--- a/lib/prayermate_api/version.rb
+++ b/lib/prayermate_api/version.rb
@@ -1,3 +1,3 @@
 module PrayerMateApi
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/test/prayermate_api_test.rb
+++ b/test/prayermate_api_test.rb
@@ -44,6 +44,22 @@ class PrayermateApiTest < Minitest::Test
           assert_equal EMAIL, api.email
         end
       end
+
+      describe "with nil parameters" do
+        it "must raise a PrayerMateApiException" do
+          assert_raises PrayerMateApi::PrayerMateApiException do
+            PrayerMateApi.api nil, HOST, API_KEY
+          end
+
+          assert_raises PrayerMateApi::PrayerMateApiException do
+            PrayerMateApi.api PROTOCOL, nil, API_KEY
+          end
+
+          assert_raises PrayerMateApi::PrayerMateApiException do
+            PrayerMateApi.api PROTOCOL, HOST, nil
+          end
+        end
+      end
     end
 
     describe "when asking for the api path" do


### PR DESCRIPTION
Allow data to be optionally submitted in `PUT` and `GET` requests too, instead of just `POST`. Also throws an exception if protocol, host, or API key are nil when creating a new API object.