### PR TITLE
Allow draft publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .idea
 
 Gemfile.lock
+
+.envrc

--- a/bin/console
+++ b/bin/console
@@ -2,9 +2,25 @@
 
 require "bundler/setup"
 require "prayermate_api"
+require "securerandom"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
+
+PROTOCOL = "http"
+HOST = "localhost:3000"
+API_KEY = ENV["PRAYERMATE_API_KEY"]
+EMAIL = ENV["EMAIL_FOR_TOKEN"]
+API_TOKEN = ENV["PRAYERMATE_API_TOKEN"]
+
+@api_without_session = PrayerMateApi.api PROTOCOL, HOST, API_KEY
+@api = PrayerMateApi.api PROTOCOL, HOST, API_KEY, PrayerMateApi.build_session(EMAIL, API_TOKEN)
+
+@petition = {
+    date: Date.today,
+    description: "test petition",
+    uid: SecureRandom.uuid
+}
 
 # (If you use this, don't forget to add pry to your Gemfile!)
 # require "pry"

--- a/lib/prayermate_api.rb
+++ b/lib/prayermate_api.rb
@@ -55,14 +55,15 @@ module PrayerMateApi
       response
     end
 
-    def update_input_feed(feed_id, user_feed_slug, petitions, last_modified)
+    def update_input_feed(feed_id, user_feed_slug, petitions, last_modified, publish_as_draft = false)
       post_with_auth("input_feeds/process", {
                       feed: {
                         id: feed_id,
                         user_feed_slug: user_feed_slug,
                         last_modified: last_modified
                       },
-                      petitions: petitions
+                      petitions: petitions,
+                      publish_as_draft: publish_as_draft
                     })
     end
 


### PR DESCRIPTION
`#update_input_feed` now allows draft publishing. Some helper methods added to console start to make manual testing easier.