### PR TITLE
Include organisation in register methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 
 .idea
 

--- a/lib/prayermate_api.rb
+++ b/lib/prayermate_api.rb
@@ -40,12 +40,12 @@ module PrayerMateApi
       HTTParty.post(api_path("images/resize"), body: { url: url, target_filename: filename }, headers: http_headers)
     end
 
-    def register_with_promo_code(promo_code, first_name, last_name, email, roles, organisation_details)
-      register({ promo_code: promo_code }.merge(organisation_details), first_name, last_name, email, roles)
+    def register_with_promo_code(promo_code, first_name, last_name, email, roles, organisation)
+      register({ promo_code: promo_code, organisation: organisation }, first_name, last_name, email, roles)
     end
 
-    def register_with_price_plan(price_plan, first_name, last_name, email, roles, organisation_details)
-      register({ price_plan: price_plan }.merge(organisation_details), first_name, last_name, email, roles)
+    def register_with_price_plan(price_plan, first_name, last_name, email, roles, organisation)
+      register({ price_plan: price_plan, organisation: organisation }, first_name, last_name, email, roles)
     end
 
 

--- a/lib/prayermate_api.rb
+++ b/lib/prayermate_api.rb
@@ -40,12 +40,12 @@ module PrayerMateApi
       HTTParty.post(api_path("images/resize"), body: { url: url, target_filename: filename }, headers: http_headers)
     end
 
-    def register_with_promo_code(promo_code, first_name, last_name, email, roles, organisation_type)
-      register({ promo_code: promo_code, organisation_type: organisation_type }, first_name, last_name, email, roles)
+    def register_with_promo_code(promo_code, first_name, last_name, email, roles, organisation_details)
+      register({ promo_code: promo_code }.merge(organisation_details), first_name, last_name, email, roles)
     end
 
-    def register_with_price_plan(price_plan, first_name, last_name, email, roles, organisation_type)
-      register({ price_plan: price_plan, organisation_type: organisation_type }, first_name, last_name, email, roles)
+    def register_with_price_plan(price_plan, first_name, last_name, email, roles, organisation_details)
+      register({ price_plan: price_plan }.merge(organisation_details), first_name, last_name, email, roles)
     end
 
 

--- a/lib/prayermate_api.rb
+++ b/lib/prayermate_api.rb
@@ -40,12 +40,12 @@ module PrayerMateApi
       HTTParty.post(api_path("images/resize"), body: { url: url, target_filename: filename }, headers: http_headers)
     end
 
-    def register_with_promo_code(promo_code, first_name, last_name, email, roles)
-      register({ promo_code: promo_code }, first_name, last_name, email, roles)
+    def register_with_promo_code(promo_code, first_name, last_name, email, roles, organisation_type)
+      register({ promo_code: promo_code, organisation_type: organisation_type }, first_name, last_name, email, roles)
     end
 
-    def register_with_price_plan(price_plan, first_name, last_name, email, roles)
-      register({ price_plan: price_plan }, first_name, last_name, email, roles)
+    def register_with_price_plan(price_plan, first_name, last_name, email, roles, organisation_type)
+      register({ price_plan: price_plan, organisation_type: organisation_type }, first_name, last_name, email, roles)
     end
 
 

--- a/lib/prayermate_api/version.rb
+++ b/lib/prayermate_api/version.rb
@@ -1,3 +1,3 @@
 module PrayerMateApi
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Include (optional) organisation type and name in register methods so organisations are created for users when registering. Bump version 0.4.0 as this is a breaking change